### PR TITLE
Make proof data public

### DIFF
--- a/src/proofs/inner_product.rs
+++ b/src/proofs/inner_product.rs
@@ -26,10 +26,10 @@ use Errors::{self, InnerProductError};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InnerProductArg {
-    pub(super) L: Vec<Point<Secp256k1>>,
-    pub(super) R: Vec<Point<Secp256k1>>,
-    pub(super) a_tag: BigInt,
-    pub(super) b_tag: BigInt,
+    pub L: Vec<Point<Secp256k1>>,
+    pub R: Vec<Point<Secp256k1>>,
+    pub a_tag: BigInt,
+    pub b_tag: BigInt,
 }
 
 impl InnerProductArg {

--- a/src/proofs/range_proof.rs
+++ b/src/proofs/range_proof.rs
@@ -31,14 +31,14 @@ use Errors::{self, RangeProofError};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RangeProof {
-    A: Point<Secp256k1>,
-    S: Point<Secp256k1>,
-    T1: Point<Secp256k1>,
-    T2: Point<Secp256k1>,
-    tau_x: Scalar<Secp256k1>,
-    miu: Scalar<Secp256k1>,
-    tx: Scalar<Secp256k1>,
-    inner_product_proof: InnerProductArg,
+    pub  A: Point<Secp256k1>,
+    pub S: Point<Secp256k1>,
+    pub T1: Point<Secp256k1>,
+    pub T2: Point<Secp256k1>,
+    pub tau_x: Scalar<Secp256k1>,
+    pub miu: Scalar<Secp256k1>,
+    pub tx: Scalar<Secp256k1>,
+    pub inner_product_proof: InnerProductArg,
 }
 
 impl RangeProof {


### PR DESCRIPTION
The sample output for using `serde_json` to serialize a `range_proof` is as follows: (note, people likely will want to remove the `curve`, nested `point`, etc..)

```
range_proof: {
"A":{"curve":"secp256k1","point":"03b6b586b9be903a7d7aad1756b2265c687cd04d2e4e891abfe2f8cf8ec486eeb6"},
"S":{"curve":"secp256k1","point":"035bd13d8c81fd0ced91fc5ecc5820d41eb1add6f1032f5408e53b08720f9ccb84"},
"T1":{"curve":"secp256k1","point":"03f9b9f84ef67bd145692eafe4f425c7bc098122f9b69b007edc38245f5a632371"},
"T2":{"curve":"secp256k1","point":"023df9b7649dd28dda232f4ca570964dbd9db2dc03d9c327ef3c80e4123c8dc8ab"},
"inner_product_proof":{
    "L":[{"curve":"secp256k1","point":"02d248a2199c712d2303c9d702ad7a40e711e11f3001e1fd19eefc72562e57e403"},{"curve":"secp256k1","point":"033bd278885e1d55317d900980775fb8db7ffeeec82ba63af094087361d57f6681"},{"curve":"secp256k1","point":"0275dcbc91dc9a44e1926b24148d95be4c080a55f7b1f032b10377d778799527d0"},{"curve":"secp256k1","point":"03f10b63c1a9f408976b58166e7104a7418b32aa4077d9c32a1a0bf26d758cc9f5"},{"curve":"secp256k1","point":"021c51ec1171ba0f4e64bcf775f491238975575996b02c480d457ab3e21684bca7"},{"curve":"secp256k1","point":"03ffcbb7b99059524d103fb63fa08dff75d27341990415e2db3f39604c5bb77bd7"},{"curve":"secp256k1","point":"03a8508a92b879a895c3a0eb4442e61ea306862fd03919aaf41b172ff73d7e1fc3"},{"curve":"secp256k1","point":"035b94bd3bb2205238f2f126e0300d3a22d65e2ea90680822936c5dd46551b0a66"}],
    "R":[{"curve":"secp256k1","point":"03d003ee983a7f0d60f9af78b3917fcd20f2c24df7f61efc1bb2271ac8178db4a4"},{"curve":"secp256k1","point":"03a754993a25c61c3e628c37e5ce085dabc69966b46fc3f1a7edf8e59d31d5bdd6"},{"curve":"secp256k1","point":"03d89c8339f6d9f68b862f23b25c174fdaacf8128e3f1b57c06879c2f644345f39"},{"curve":"secp256k1","point":"020ff1a416a07bc3eddfddfacea07269ecb3ab6bed460e4e69508c1bc6b5380f1a"},{"curve":"secp256k1","point":"02dbe1285b1b826f4746a6b4dedd86d1e3e5cdf63bd0a0cbd1cfa67a55ac5a1424"},{"curve":"secp256k1","point":"0310d41d9751e526f917f50d5ecabf1251dff6486ba56a25a32b362e4dac542b77"},{"curve":"secp256k1","point":"039e65d4eee4fe41e5c6597337b34a242bb5ae3b7cc93c8a651848726a3f0605c5"},{"curve":"secp256k1","point":"03021cc462722027898c5fe73bffed2db0f293b1fb19a72df4226a64dbe51e6ed0"}],
    "a_tag":"8ad20e6fd5182b8e37e74d9406491b54bbd2edea4c4fdfb4899c48b9008de60e",
    "b_tag":"2ba9f2e579ac900cb1fe1e9fb4b58ba89d6bffae33f8f3867319049cf7ad9c4a"
},
"miu":{"curve":"secp256k1","scalar":"c8894df9a80ecdddf4bb0bf5d9b45f08d17352e882138b14aaf3ffd1e87e77a2"},
"tau_x":{"curve":"secp256k1","scalar":"93f8c0484626b93ca9a08ae85e804df746aa3a17b3a644700036923061452f4c"},
"tx":{"curve":"secp256k1","scalar":"cec0097515d27983bd7e6224760117c4e6454e9bb98603ec5818652e3bda9e28"}}
```

It can be difficult to retrieve and serialize the fields in the desired way for the caller because they are not visible outside of the crate. However, since there is no security risk associated with exposing these fields as they will be persisted in files anyway, it may be a better option to make them publicly visible.